### PR TITLE
Never fail on rate limiting

### DIFF
--- a/lib/cfncli/event_streamer.rb
+++ b/lib/cfncli/event_streamer.rb
@@ -31,7 +31,9 @@ module CfnCli
       events.sort { |a, b| a.timestamp <=> b.timestamp }.each do |event|
         yield event unless seen?(event) if block_given?
       end
-   end
+    rescue Aws::CloudFormation::Errors::ServiceError => e
+      raise unless e.name == 'Aws::CloudFormation::Errors::Throttling'
+    end
 
     # Mark all the existing events as 'seen'
     def reset_events


### PR DESCRIPTION
Will do nothing if the CLI throws a rate limit exception, but all others will still be raised normally
